### PR TITLE
Add a `lib` schema

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -135,6 +135,22 @@
           recurse "" output;
       };
 
+      libSchema = {
+        version = 1;
+        doc = ''
+          The `lib` flake output exposes arbitrary Nix terms.
+        '';
+        inventory = let
+          processValue = value: let
+            what = builtins.typeOf value;
+          in
+          if what == "set" then
+            self.lib.mkChildren
+            (builtins.mapAttrs (name: processValue) value)
+          else {inherit what;};
+        in processValue;
+      };
+
       overlaysSchema = {
         version = 1;
         doc = ''
@@ -218,6 +234,7 @@
       schemas.checks = checksSchema;
       schemas.devShells = devShellsSchema;
       schemas.hydraJobs = hydraJobsSchema;
+      schemas.lib = libSchema;
       schemas.overlays = overlaysSchema;
       schemas.nixosConfigurations = nixosConfigurationsSchema;
       schemas.nixosModules = nixosModulesSchema;


### PR DESCRIPTION
It recurses into attrSets, showing all the terms of the `lib` output.

Here's an example `nix flake show`:
```
⋮
├───lib
│   ├───configuration: lambda
│   ├───defaultConfiguration: lambda
│   └───just
│       └───some
│           └───nested
│               └───values
│                   ├───aList: list
│                   ├───aPath: path
│                   ├───aString: string
│                   ├───anInt: int
│                   └───itsNull: null
⋮
```