### PR TITLE
Check that modules are a function or an attrset

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,9 @@
         drv.type or null == "derivation"
         && drv ? drvPath;
 
+      checkModule = module:
+        builtins.isAttrs module || builtins.isFunction module;
+
       schemasSchema = {
         version = 1;
         doc = ''
@@ -246,6 +249,7 @@
           (moduleName: module:
             {
               what = "NixOS module";
+              evalChecks.isFunctionOrAttrs = checkModule module;
             })
           output);
       };

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,9 @@
 
       checkDerivation = drv:
         drv.type or null == "derivation"
-        && drv ? drvPath;
+        && drv ? drvPath
+        && drv ? name
+        && builtins.isString drv.name;
 
       checkModule = module:
         builtins.isAttrs module || builtins.isFunction module;

--- a/flake.nix
+++ b/flake.nix
@@ -221,7 +221,10 @@
                 # Nixpkgs.  But we don't have access to a nixpkgs
                 # flake here. Maybe this schema should be moved to the
                 # nixpkgs flake, where it does have access.
-                builtins.isAttrs (overlay { } { });
+                if !builtins.isFunction overlay then
+                  throw "overlay is not a function, but a set instead"
+                else
+                  builtins.isAttrs (overlay { } { });
             })
           output);
       };


### PR DESCRIPTION
Also improves the error message if an overlay is not a function.