### PR TITLE
Emit an attribute for legacyPackages that fail to evaluate

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -113,7 +113,10 @@
                               else
                                 [ ]
                           )
-                          [ ])
+                          [{
+                            name = attrName;
+                            value = throw "failed";
+                          }])
                       attrs));
                   in
                   # The top-level cannot be a derivation.


### PR DESCRIPTION
E.g. `AAAAAASomeThingsFailToEvaluate` in Nixpkgs. This fixes a test in Nix's test suite.