### PR TITLE
nixosConfigurationsSchema: use `pkgs.stdenv.system`, not `pkgs.system`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -252,7 +252,7 @@
             {
               what = "NixOS configuration";
               derivation = machine.config.system.build.toplevel;
-              forSystems = [ machine.pkgs.system ];
+              forSystems = [ machine.pkgs.stdenv.system ];
             })
           output);
       };


### PR DESCRIPTION
`pkgs.system` doesn't work when the `pkgs` has `allowAliases = false;` set in its configuration.