### PR TITLE
homeConfigurations, darwinConfigurations: set forSystems

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -281,7 +281,7 @@
             {
               what = "Home Manager configuration";
               derivation = this.activationPackage;
-              forSystems = [ derivation.system ];
+              forSystems = [ this.activationPackage.system ];
             })
           output);
       };
@@ -296,7 +296,7 @@
             {
               what = "nix-darwin configuration";
               derivation = this.system;
-              forSystems = [ derivation.system ];
+              forSystems = [ this.system.system ];
             })
           output);
       };

--- a/flake.nix
+++ b/flake.nix
@@ -281,6 +281,7 @@
             {
               what = "Home Manager configuration";
               derivation = this.activationPackage;
+              forSystems = [ derivation.system ];
             })
           output);
       };
@@ -295,6 +296,7 @@
             {
               what = "nix-darwin configuration";
               derivation = this.system;
+              forSystems = [ derivation.system ];
             })
           output);
       };


### PR DESCRIPTION
This allows flake-iter and DeterminateSystems/ci to automatically build them.