### PR TITLE
Add `shortDescription` to `appsSchema`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,7 @@
                         && app ? program
                         && builtins.isString app.program;
                       what = "app";
+                      shortDescription = app.description or "";
                     })
                     apps;
               })


### PR DESCRIPTION
Flake `apps` could benefit from a description. As an example, here’s a simple flake:

```nix
{
  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
  outputs = { self, nixpkgs, ... }:{
    apps.aarch64-darwin.hello = {
      program = "${nixpkgs.lib.getExe nixpkgs.legacyPackages.aarch64-darwin.hello}";
      type = "app";
      description = "I say hello!";
    };
  };
}
```

and the corresponding `nix flake show --default-flake-schemas github:shivaraj-bh/flake-schemas/apps --json` output, where `nix` is compiled from https://github.com/DeterminateSystems/nix-src/tree/flake-schemas:

```json
{
  "apps": {
    "doc": "The `apps` output provides commands available via `nix run`.\n",
    "output": {
      "children": {
        "aarch64-darwin": {
          "children": {
            "hello": {
              "leaf": true,
              "shortDescription": "I say hello!",
              "what": "app"
            }
          }
        }
      }
    }
  },
  ...
}
```

## Question

Should we stick to the `meta` attribute of derivations for `apps` as well?