### PR TITLE
Detect if an app output has unsupported attributes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -56,7 +56,8 @@
                         app ? type
                         && app.type == "app"
                         && app ? program
-                        && builtins.isString app.program;
+                        && builtins.isString app.program
+                        && builtins.removeAttrs app ["type" "program" "meta"] == {};
                       what = "app";
                     })
                     apps;


### PR DESCRIPTION
This brings it in sync with pre-flake-schemas `nix flake check`.