### PR TITLE
warn users about "unknown flake output 'schemas'" warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,13 @@
 > [!NOTE]
 > Flake schemas are not yet supported in Nix.
 > You can track ongoing work in [this pull request][pr] against the upstream project.
-> Until that merges, you can [experiment with flake schemas](#experimenting-with-flake-schemas) using a candidate version of Nix.
+> Until that merges, you may see this warning:
+>
+> ```sh
+> warning: unknown flake output 'schemas'
+> ```
+>
+> You can also [experiment with flake schemas](#experimenting-with-flake-schemas) using a candidate version of Nix.
 
 This [Nix flake][flakes] provides a set of schema definitions for commonly used flake output types.
 It's used by default for flakes that do not have a `schemas` output.


### PR DESCRIPTION
I was a bit confused by this and wondered whether this could be avoided.

@lucperkins kindly informed me over an Discord that this to be expected until https://github.com/NixOS/nix/pull/8892 merges.