### PR TITLE
Update old nixos wiki links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,9 @@ nix develop ./tests -c treefmt
 [legacy]: https://github.com/NixOS/nixpkgs/blob/d1eaf1acfce382f14d26d20e0a9342884f3127b0/flake.nix#L47-L56
 [nix-flake-show]: https://manual.determinate.systems/command-ref/new-cli/nix3-flake-show.html
 [nixos]: https://github.com/NixOS/nixpkgs/tree/master/nixos
-[nixosmodules]: https://nixos.wiki/wiki/NixOS_modules
+[nixosmodules]: https://wiki.nixos.org/wiki/NixOS_Modules
 [oci]: https://opencontainers.org
-[overlays]: https://nixos.wiki/wiki/Overlays
+[overlays]: https://wiki.nixos.org/wiki/Overlays
 [packages]: https://search.nixos.org/packages
 [post]: https://determinate.systems/blog/introducing-flake-schemas
 [templates]: https://manual.determinate.systems/command-ref/new-cli/nix3-flake-init.html


### PR DESCRIPTION
I'm working on replacing all references to `nixos.wiki` with `wiki.nixos.org` across all nix-related repos. This increases visibility of the official wiki so that someday there will no longer be any confusion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated reference links for NixOS modules and overlays documentation to use current wiki URLs with corrected path formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeterminateSystems/flake-schemas/pull/62?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->