### PR TITLE
Update Nix input in tests flake

### DIFF
--- a/tests/flake.lock
+++ b/tests/flake.lock
@@ -80,32 +80,30 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1772194520,
-        "narHash": "sha256-CI/VDQB4zUaEkPKLQEg+9sWwHQw9ROUqkghQEqBptec=",
-        "owner": "DeterminateSystems",
-        "repo": "nix-src",
-        "rev": "4aadc97cfae1b773cbdefdee42e694c9179d2c16",
-        "type": "github"
+        "lastModified": 1779472733,
+        "narHash": "sha256-nV5OHwivEf392cB5MDwoVdDHSvy6Q+rRYZBHd9sePj4=",
+        "rev": "11f3aff904f84ae612e36e8bc578ac421fca74fa",
+        "revCount": 25967,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/nix-src/3.21.0/019e50fb-8633-73d0-b673-b2e265950490/source.tar.gz"
       },
       "original": {
-        "owner": "DeterminateSystems",
-        "ref": "flake-schemas-detsys",
-        "repo": "nix-src",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://flakehub.com/f/DeterminateSystems/nix-src/3"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1761597516,
-        "narHash": "sha256-wxX7u6D2rpkJLWkZ2E932SIvDJW8+ON/0Yy8+a5vsDU=",
-        "rev": "daf6dc47aa4b44791372d6139ab7b25269184d55",
-        "revCount": 811874,
+        "lastModified": 1773222311,
+        "narHash": "sha256-BHoB/XpbqoZkVYZCfXJXfkR+GXFqwb/4zbWnOr2cRcU=",
+        "rev": "0590cd39f728e129122770c029970378a79d076a",
+        "revCount": 909248,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2505.811874%2Brev-daf6dc47aa4b44791372d6139ab7b25269184d55/019a3494-3498-707e-9086-1fb81badc7fe/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2511.909248%2Brev-0590cd39f728e129122770c029970378a79d076a/019ce32b-8ace-7339-b129-cceaa8dd10c6/source.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.2505"
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.2511"
       }
     },
     "nixpkgs-23-11": {

--- a/tests/flake.nix
+++ b/tests/flake.nix
@@ -1,7 +1,6 @@
 {
   inputs.flake-schemas.url = "path:..";
-  # FIXME: use regular Nix after flake-schemas have been merged.
-  inputs.nix.url = "github:DeterminateSystems/nix-src/flake-schemas-detsys";
+  inputs.nix.url = "https://flakehub.com/f/DeterminateSystems/nix-src/3";
   inputs.nixpkgs.follows = "nix/nixpkgs";
 
   outputs =


### PR DESCRIPTION
Now that Determinate Nix supports flake schemas, we no longer need to rely on a specific branch in the test suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated flake input configuration to use new source location.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/DeterminateSystems/flake-schemas/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->